### PR TITLE
バグ修正でとちったのでリカバリ

### DIFF
--- a/orchestration/7dtd/ap-northeast-1/lambda/instance_up/instance_up.py
+++ b/orchestration/7dtd/ap-northeast-1/lambda/instance_up/instance_up.py
@@ -7,7 +7,7 @@ import time
 spot_price                 = '0.15'
 instance_count             = 1
 request_type               = 'request'
-image_id                   = 'ami-0763a0836f4812f45'
+image_id                   = 'ami-0ad2296f162940437'
 security_group_id          = 'sg-03e83d20acec854f7'
 instance_type              = 'c5.xlarge'
 availability_zone          = 'ap-northeast-1d'

--- a/provisioning/hosts/games/vars/_7dtd.yml
+++ b/provisioning/hosts/games/vars/_7dtd.yml
@@ -1,5 +1,5 @@
 ---
 user: game-user
 group: game-user
-volume_id: "vol-0859fdc4be99fbfd4"
+volume_id: "vol-01a6e6b3ada88dd7f"
 seed: "gunkan"


### PR DESCRIPTION
## 概要
この前、久々にやったら7dtdに入れなかった時に一度ebsをスナップショットから復元したり色々して最終的にゲームのデータをマルっと消してやり直した時に元のebsではなくスナップショットから復元ebsの方でゲームやっちゃってたのでebsを乗り換える
provisioningを修正したので修正後amiには焼いた
その影響でinstance_upで呼び出すami idを直す必要もあった