### PR TITLE
terraformにバージョンアップがきててtfstateがうまく機能していなかったので修正

### DIFF
--- a/orchestration/7dtd/ap-northeast-1/terraform.tfstate
+++ b/orchestration/7dtd/ap-northeast-1/terraform.tfstate
@@ -1,7 +1,7 @@
 {
   "version": 4,
-  "terraform_version": "0.12.26",
-  "serial": 169,
+  "terraform_version": "0.13.5",
+  "serial": 170,
   "lineage": "1acb505c-d66d-bb82-7535-f3f68337f371",
   "outputs": {},
   "resources": [
@@ -9,7 +9,7 @@
       "mode": "data",
       "type": "aws_ssm_parameter",
       "name": "amzn2_ami",
-      "provider": "provider.aws",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -18,8 +18,8 @@
             "id": "/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2",
             "name": "/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2",
             "type": "String",
-            "value": "ami-0a1c2ec61571737db",
-            "version": 30,
+            "value": "ami-0992fc94ca0f1415a",
+            "version": 39,
             "with_decryption": true
           }
         }
@@ -29,7 +29,7 @@
       "mode": "managed",
       "type": "aws_api_gateway_deployment",
       "name": "_7dtd_deployment",
-      "provider": "provider.aws",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -60,7 +60,7 @@
       "mode": "managed",
       "type": "aws_api_gateway_integration",
       "name": "instance_down",
-      "provider": "provider.aws",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -100,7 +100,7 @@
       "mode": "managed",
       "type": "aws_api_gateway_integration",
       "name": "instance_up",
-      "provider": "provider.aws",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -140,7 +140,7 @@
       "mode": "managed",
       "type": "aws_api_gateway_integration_response",
       "name": "instance_down_post_200",
-      "provider": "provider.aws",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -172,7 +172,7 @@
       "mode": "managed",
       "type": "aws_api_gateway_integration_response",
       "name": "instance_down_post_500",
-      "provider": "provider.aws",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -206,7 +206,7 @@
       "mode": "managed",
       "type": "aws_api_gateway_integration_response",
       "name": "instance_up_post_200",
-      "provider": "provider.aws",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -238,7 +238,7 @@
       "mode": "managed",
       "type": "aws_api_gateway_integration_response",
       "name": "instance_up_post_500",
-      "provider": "provider.aws",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -272,7 +272,7 @@
       "mode": "managed",
       "type": "aws_api_gateway_method",
       "name": "instance_down",
-      "provider": "provider.aws",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -302,7 +302,7 @@
       "mode": "managed",
       "type": "aws_api_gateway_method",
       "name": "instance_up",
-      "provider": "provider.aws",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -332,7 +332,7 @@
       "mode": "managed",
       "type": "aws_api_gateway_method_response",
       "name": "instance_down_200",
-      "provider": "provider.aws",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -359,7 +359,7 @@
       "mode": "managed",
       "type": "aws_api_gateway_method_response",
       "name": "instance_down_500",
-      "provider": "provider.aws",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -387,7 +387,7 @@
       "mode": "managed",
       "type": "aws_api_gateway_method_response",
       "name": "instance_up_200",
-      "provider": "provider.aws",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -414,7 +414,7 @@
       "mode": "managed",
       "type": "aws_api_gateway_method_response",
       "name": "instance_up_500",
-      "provider": "provider.aws",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -442,7 +442,7 @@
       "mode": "managed",
       "type": "aws_api_gateway_resource",
       "name": "instance_down",
-      "provider": "provider.aws",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -464,7 +464,7 @@
       "mode": "managed",
       "type": "aws_api_gateway_resource",
       "name": "instance_up",
-      "provider": "provider.aws",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -486,7 +486,7 @@
       "mode": "managed",
       "type": "aws_api_gateway_rest_api",
       "name": "_7dtd",
-      "provider": "provider.aws",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -521,7 +521,7 @@
       "mode": "managed",
       "type": "aws_cloudwatch_event_rule",
       "name": "notice_public_ip_to_slack_lambda_event_rule",
-      "provider": "provider.aws",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -545,7 +545,7 @@
       "mode": "managed",
       "type": "aws_cloudwatch_event_rule",
       "name": "notice_terminate_to_slack_lambda_event_rule",
-      "provider": "provider.aws",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -569,7 +569,7 @@
       "mode": "managed",
       "type": "aws_cloudwatch_event_target",
       "name": "notice_public_ip_to_slack_lambda_event_target",
-      "provider": "provider.aws",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -601,7 +601,7 @@
       "mode": "managed",
       "type": "aws_cloudwatch_event_target",
       "name": "notice_terminate_to_slack_lambda_event_target",
-      "provider": "provider.aws",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -633,7 +633,7 @@
       "mode": "managed",
       "type": "aws_default_route_table",
       "name": "default",
-      "provider": "provider.aws",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -672,7 +672,7 @@
       "mode": "managed",
       "type": "aws_ebs_volume",
       "name": "volume",
-      "provider": "provider.aws",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -700,7 +700,7 @@
       "mode": "managed",
       "type": "aws_iam_role",
       "name": "iam_for_lambda",
-      "provider": "provider.aws",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -727,7 +727,7 @@
       "mode": "managed",
       "type": "aws_iam_role_policy",
       "name": "for_lambda",
-      "provider": "provider.aws",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -749,11 +749,12 @@
       "mode": "managed",
       "type": "aws_internet_gateway",
       "name": "public",
-      "provider": "provider.aws",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
           "attributes": {
+            "arn": "arn:aws:ec2:ap-northeast-1:886398035123:internet-gateway/igw-063cd35cde328837a",
             "id": "igw-063cd35cde328837a",
             "owner_id": "886398035123",
             "tags": {
@@ -772,11 +773,12 @@
       "mode": "managed",
       "type": "aws_key_pair",
       "name": "access_7dtd_instance",
-      "provider": "provider.aws",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 1,
           "attributes": {
+            "arn": "arn:aws:ec2:ap-northeast-1:886398035123:key-pair/7dtd-instance-access-key",
             "fingerprint": "ea:5c:f3:86:dc:8b:7e:ea:56:04:e2:f6:1d:c1:88:dd",
             "id": "7dtd-instance-access-key",
             "key_name": "7dtd-instance-access-key",
@@ -793,7 +795,7 @@
       "mode": "managed",
       "type": "aws_lambda_function",
       "name": "instance_down_lambda",
-      "provider": "provider.aws",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -802,6 +804,7 @@
             "dead_letter_config": [],
             "description": "",
             "environment": [],
+            "file_system_config": [],
             "filename": "lambda/instance_down/lambda_handler.zip",
             "function_name": "7dtd_instance_down",
             "handler": "instance_down.lambda_handler",
@@ -843,7 +846,7 @@
       "mode": "managed",
       "type": "aws_lambda_function",
       "name": "instance_up_lambda",
-      "provider": "provider.aws",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -852,6 +855,7 @@
             "dead_letter_config": [],
             "description": "",
             "environment": [],
+            "file_system_config": [],
             "filename": "lambda/instance_up/lambda_handler.zip",
             "function_name": "7dtd_instance_up",
             "handler": "instance_up.lambda_handler",
@@ -893,7 +897,7 @@
       "mode": "managed",
       "type": "aws_lambda_function",
       "name": "notice_public_ip_to_slack_lambda",
-      "provider": "provider.aws",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -908,6 +912,7 @@
                 }
               }
             ],
+            "file_system_config": [],
             "filename": "lambda/notice_public_ip_to_slack_lambda/lambda_handler.zip",
             "function_name": "notice_public_ip_to_slack_lambda",
             "handler": "notice_public_ip_to_slack_lambda.lambda_handler",
@@ -949,7 +954,7 @@
       "mode": "managed",
       "type": "aws_lambda_function",
       "name": "notice_terminate_to_slack_lambda",
-      "provider": "provider.aws",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -964,6 +969,7 @@
                 }
               }
             ],
+            "file_system_config": [],
             "filename": "lambda/notice_terminate_to_slack_lambda/lambda_handler.zip",
             "function_name": "notice_terminate_to_slack_lambda",
             "handler": "notice_terminate_to_slack_lambda.lambda_handler",
@@ -1005,7 +1011,7 @@
       "mode": "managed",
       "type": "aws_lambda_permission",
       "name": "allow_cloudwatch_to_call_notice_public_ip_to_slack",
-      "provider": "provider.aws",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -1034,7 +1040,7 @@
       "mode": "managed",
       "type": "aws_lambda_permission",
       "name": "allow_cloudwatch_to_call_notice_terminate_to_slack",
-      "provider": "provider.aws",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -1063,7 +1069,7 @@
       "mode": "managed",
       "type": "aws_lambda_permission",
       "name": "instance_down",
-      "provider": "provider.aws",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -1090,7 +1096,7 @@
       "mode": "managed",
       "type": "aws_lambda_permission",
       "name": "instance_up",
-      "provider": "provider.aws",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -1117,7 +1123,7 @@
       "mode": "managed",
       "type": "aws_main_route_table_association",
       "name": "default",
-      "provider": "provider.aws",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -1140,7 +1146,7 @@
       "mode": "managed",
       "type": "aws_route_table_association",
       "name": "default_public",
-      "provider": "provider.aws",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
@@ -1163,7 +1169,7 @@
       "mode": "managed",
       "type": "aws_security_group",
       "name": "_7dtd_security_group",
-      "provider": "provider.aws",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 1,
@@ -1298,7 +1304,7 @@
       "mode": "managed",
       "type": "aws_subnet",
       "name": "public",
-      "provider": "provider.aws",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 1,
@@ -1331,7 +1337,7 @@
       "mode": "managed",
       "type": "aws_vpc",
       "name": "vpc",
-      "provider": "provider.aws",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 1,


### PR DESCRIPTION
https://blog.n-t.jp/tech/terraform-error-invalid-legacy-provider-address/
の通りに実施した結果の terraform.tfstate をpushしてる